### PR TITLE
PLAT-993: Change operator image repo name and increase build verbosity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ bin/*: deps
 
 tools: export GO111MODULE=off
 tools:
-	go get -u "github.com/golangci/golangci-lint/cmd/golangci-lint"
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.25.0
 	go get -u "github.com/ory/go-acc"
 
 deps: tools

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GOFLAGS := -ldflags=-w
 GOFLAGS := $(GOFLAGS) -ldflags=-X=$(REPO)/pkg/version.Version=$(RELEASE_VERSION)
 GOFLAGS := "$(GOFLAGS) -ldflags=-X=$(REPO)/pkg/version.Commit=$(COMMIT)"
 
-OPERATOR_IMAGE_REPO ?= quay.io/getpantheon/cos-update-operator-operator
+OPERATOR_IMAGE_REPO ?= quay.io/getpantheon/cos-update-operator
 AGENT_IMAGE_REPO ?= quay.io/getpantheon/cos-update-operator-agent
 
 KUBE_NAMESPACE ?= $(shell kubectl config get-contexts \

--- a/Makefile
+++ b/Makefile
@@ -29,15 +29,15 @@ all: bin/* test lint coverage
 
 # used for caching golangci-lint data in circleci
 master-sha:
-	@git fetch origin && git rev-parse origin/master > master_sha
+	git fetch origin && git rev-parse origin/master > master_sha
 
 test: deps
 bin/*: deps
 
 tools: export GO111MODULE=off
 tools:
-	go get -u "github.com/golangci/golangci-lint/cmd/golangci-lint" > /dev/null
-	go get -u "github.com/ory/go-acc" > /dev/null
+	go get -u "github.com/golangci/golangci-lint/cmd/golangci-lint"
+	go get -u "github.com/ory/go-acc"
 
 deps: tools
 	go get ./...
@@ -66,25 +66,25 @@ coverage:
 	go-acc ./...
 
 agent-image: bin/update-agent
-	@docker build -t $(AGENT_IMAGE_REPO):$(VERSION) --build-arg=cmd=update-agent .
+	docker build -t $(AGENT_IMAGE_REPO):$(VERSION) --build-arg=cmd=update-agent .
 
 operator-image: bin/update-operator
-	@docker build -t $(OPERATOR_IMAGE_REPO):$(VERSION) --build-arg=cmd=update-operator .
+	docker build -t $(OPERATOR_IMAGE_REPO):$(VERSION) --build-arg=cmd=update-operator .
 
 image: agent-image
 image: operator-image
 
 push-agent: agent-image
-	@docker push $(AGENT_IMAGE_REPO):$(VERSION)
+	docker push $(AGENT_IMAGE_REPO):$(VERSION)
 
 push-operator: operator-image
-	@docker push $(OPERATOR_IMAGE_REPO):$(VERSION)
+	docker push $(OPERATOR_IMAGE_REPO):$(VERSION)
 
 push: push-agent push-operator
 
 ko: export KO_DOCKER_REPO=us-central1-docker.pkg.dev/pantheon-sandbox/pantheon-sandbox-public
 ko:
-	@ko apply -f k8s/daemonset.yaml
+	ko apply -f k8s/daemonset.yaml
 
 clean:
 	rm -rf bin


### PR DESCRIPTION
Also install specific version of golangci-lint, since golangci-lint@master is currently broken.