### PR TITLE
PLAT-993: Gate draining pods with a flag

### DIFF
--- a/cmd/update-agent/main.go
+++ b/cmd/update-agent/main.go
@@ -17,6 +17,7 @@ var (
 	node         = flag.String("node", "", "Kubernetes node name")
 	printVersion = flag.Bool("version", false, "Print version and exit")
 	reapTimeout  = flag.Int("grace-period", 600, "Period of time in seconds given to a pod to terminate when rebooting for an update")
+	drainPods    = flag.Bool("drain-pods", false, "If true, drain the pods from the node before rebooting")
 )
 
 func main() {
@@ -39,7 +40,7 @@ func main() {
 	}
 
 	rt := time.Duration(*reapTimeout) * time.Second
-	a, err := agent.New(*node, rt)
+	a, err := agent.New(*node, rt, *drainPods)
 	if err != nil {
 		glog.Fatalf("Failed to initialize %s: %v", os.Args[0], err)
 	}

--- a/pkg/updateengine/client.go
+++ b/pkg/updateengine/client.go
@@ -109,6 +109,9 @@ func (c *Client) ReceiveStatuses(rcvr chan *StatusResult, stop <-chan struct{}) 
 		case <-stop:
 			return
 		case signal := <-c.ch:
+			if signal == nil {
+				return
+			}
 			rcvr <- NewStatus(signal.Body)
 		}
 	}


### PR DESCRIPTION
Draining our all our daemonset pods doesn't make sense, because even though the cos-update-agent marks the node as unschedulable the daemonsets all tolerate the `node.kubernetes.io/unschedulable` taint. So they'll just come right back before the reboot has a chance to happen.

There's an enhancement we could do to make our draining smarter with our daemonsets, but that's follow-on work. Some discussion here: https://github.com/pantheon-systems/cos-update-operator/pull/5

So for now just add a flag that gates the draining, and default it to false.

Also fix a panic that sometimes happens right after the reboot call is made, which doesn't effect anything but looks scary in the logs:
```
I0430 21:35:32.721266       1 agent.go:234] Node drained, rebooting
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x103965d]

goroutine 67 [running]:
github.com/pantheon-systems/cos-update-operator/pkg/updateengine.(*Client).ReceiveStatuses(0xc0004a8420, 0xc000460000, 0xc000182e40)
	/Users/joeburianek/workspace/cos-update-operator/pkg/updateengine/client.go:112 +0x8d
created by github.com/pantheon-systems/cos-update-operator/pkg/agent.(*Klocksmith).watchUpdateStatus
	/Users/joeburianek/workspace/cos-update-operator/pkg/agent/agent.go:306 +0xdd
```