### PR TITLE
PLAT-993: Add a `--wait-for-pod-label` flag

### DIFF
--- a/cmd/update-agent/main.go
+++ b/cmd/update-agent/main.go
@@ -14,10 +14,11 @@ import (
 )
 
 var (
-	node         = flag.String("node", "", "Kubernetes node name")
-	printVersion = flag.Bool("version", false, "Print version and exit")
-	reapTimeout  = flag.Int("grace-period", 600, "Period of time in seconds given to a pod to terminate when rebooting for an update")
-	drainPods    = flag.Bool("drain-pods", false, "If true, drain the pods from the node before rebooting")
+	node            = flag.String("node", "", "Kubernetes node name")
+	printVersion    = flag.Bool("version", false, "Print version and exit")
+	reapTimeout     = flag.Int("grace-period", 600, "Period of time in seconds given to a pod to terminate when rebooting for an update")
+	drainPods       = flag.Bool("drain-pods", false, "If true, drain the pods from the node before rebooting")
+	waitForPodLabel = flag.String("wait-for-pod-label", "", "If set, wait for a pod running on this node matching the provided label")
 )
 
 func main() {
@@ -40,7 +41,7 @@ func main() {
 	}
 
 	rt := time.Duration(*reapTimeout) * time.Second
-	a, err := agent.New(*node, rt, *drainPods)
+	a, err := agent.New(*node, rt, *drainPods, *waitForPodLabel)
 	if err != nil {
 		glog.Fatalf("Failed to initialize %s: %v", os.Args[0], err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/mock v1.2.0
 	github.com/golang/protobuf v1.4.0
+	github.com/pkg/errors v0.8.0
 	google.golang.org/protobuf v1.21.0
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,7 @@ github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtP
 github.com/pelletier/go-toml v1.0.1/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v0.0.0-20160930220758-4d0e916071f6/go.mod h1:NxmoDg/QLVWluQDUYG7XBZTLUpKeFa8e3aMf1BfjyHk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -463,7 +463,7 @@ func (k *Klocksmith) waitForPodWithLabel() error {
 
 	for {
 		glog.Infof("Waiting for pod running on this node matching label: %s", k.waitForPodLabel)
-		time.Sleep(30 * time.Second)
+		time.Sleep(defaultPollInterval)
 
 		podList, err := k.kc.CoreV1().Pods(v1.NamespaceAll).List(v1meta.ListOptions{
 			FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": k.node}).String(),

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -2,13 +2,14 @@ package agent
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/coreos/go-systemd/login1"
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
+
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -89,7 +90,7 @@ func (k *Klocksmith) Run(stop <-chan struct{}) {
 // the stop channel is closed.
 func (k *Klocksmith) process(stop <-chan struct{}) error {
 	if err := k.waitForPodWithLabel(); err != nil {
-		return fmt.Errorf("failed to wait for pod with label: %v", err)
+		return errors.Wrap(err, "failed to wait for pod with label")
 	}
 
 	glog.Info("Setting info labels")
@@ -470,7 +471,7 @@ func (k *Klocksmith) waitForPodWithLabel() error {
 			LabelSelector: k.waitForPodLabel,
 		})
 		if err != nil {
-			return fmt.Errorf("Failed to get pods matching label '%s': %v", k.waitForPodLabel, err)
+			return errors.Wrapf(err, "failed to get pods matching label: %s", k.waitForPodLabel)
 		}
 
 		for _, pod := range podList.Items {


### PR DESCRIPTION
This flag makes the agent wait until a particular pod is in the `Running` state before starting up the agent.

Our use case is to make sure the operator waits until containers.slice is up on each node before continuing on to the next node.

Here is how to operator detects nodes that have just rebooted: https://github.com/pantheon-systems/cos-update-operator/blob/master/pkg/operator/operator.go#L47-L58

This means we can prevent the operator from continuing to the next node by simply preventing the agent from starting up after a reboot. So if we set the flag to `app=pantheon-node-agent` then the coordination between the operator and agents will ensure that pantheon-node-agent is up on the previous node before the operator proceeds to reboot the next node.