### PR TITLE
Tag master images, and support branch names with slashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ ifneq ($(VERSION), $(RELEASE_VERSION))
 endif
 
 ifneq ($(CIRCLE_BRANCH),)
-    VERSION := $(CIRCLE_BUILD_NUM)-$(CIRCLE_BRANCH)
+    BRANCH_LAST_PART := $(lastword $(subst /, ,$(CIRCLE_BRANCH)))
+    VERSION := $(CIRCLE_BUILD_NUM)-$(BRANCH_LAST_PART)
 endif
 
 REPO=github.com/pantheon-systems/cos-update-operator
@@ -79,9 +80,17 @@ image: operator-image
 
 push-agent: agent-image
 	docker push $(AGENT_IMAGE_REPO):$(VERSION)
+ifeq ($(CIRCLE_BRANCH),master)
+	docker tag $(AGENT_IMAGE_REPO):$(VERSION) $(AGENT_IMAGE_REPO):master
+	docker push $(AGENT_IMAGE_REPO):master
+endif
 
 push-operator: operator-image
 	docker push $(OPERATOR_IMAGE_REPO):$(VERSION)
+ifeq ($(CIRCLE_BRANCH),master)
+	docker tag $(OPERATOR_IMAGE_REPO):$(VERSION) $(OPERATOR_IMAGE_REPO):master
+	docker push $(OPERATOR_IMAGE_REPO):master
+endif
 
 push: push-agent push-operator
 


### PR DESCRIPTION
If a branch name has a slash in it, we'll get an error like this when trying to build:
```
docker build -t quay.io/getpantheon/cos-update-operator-agent:93-dependabot/go_modules/github.com/pkg/errors-0.9.1 --build-arg=cmd=update-agent .
invalid argument "quay.io/getpantheon/cos-update-operator-agent:93-dependabot/go_modules/github.com/pkg/errors-0.9.1" for "-t, --tag" flag: invalid reference format
See 'docker build --help'.
make: *** [Makefile:72: agent-image] Error 125
```

To fix this, just grab the last thing after the slash.

Also, when building master, tag it to make it extra clear which build is the latest in quay.