### PR TITLE
Adds circleci 'docker-executor-auth' context.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,5 +88,7 @@ workflows:
     jobs:
       - test
       - release:
+          context:
+            - docker-executor-auth
           requires:
             - test


### PR DESCRIPTION
Rotating CircleCI environment variables

Moving env vars to context so rotating can be done at the context-level. The secret environment variables have been deleted from this project in CircleCI and instead the context is being used. 

- Removed reference to Slack orb as it was not being used anywhere in the workflow.

https://app.circleci.com/settings/project/github/pantheon-systems/cos-update-operator/environment-variables

## Issue ID
https://getpantheon.atlassian.net/browse/PLAT-2878